### PR TITLE
Ensure that stderr is not returned if exit status of kubectl is 0

### DIFF
--- a/kubectl/kubectl.go
+++ b/kubectl/kubectl.go
@@ -27,9 +27,14 @@ func (t *KubeCtl) Run(stdin []byte, args ...string) (string, error) {
 	if stdin != nil {
 		cmd.Stdin = bytes.NewReader(stdin)
 	}
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("Kubectl failed: %s, %s", err, out)
+		errmsg := err.Error()
+		exiterr, ok := err.(*exec.ExitError)
+		if ok {
+			errmsg = string(exiterr.Stderr)
+		}
+		return "", fmt.Errorf("Kubectl %v failed: %s, %s", args, errmsg, out)
 	}
 	return string(out), nil
 }

--- a/kubectl/kubectl.go
+++ b/kubectl/kubectl.go
@@ -32,7 +32,7 @@ func (t *KubeCtl) Run(stdin []byte, args ...string) (string, error) {
 		errmsg := err.Error()
 		exiterr, ok := err.(*exec.ExitError)
 		if ok {
-			errmsg = string(exiterr.Stderr)
+			errmsg = fmt.Sprintf("%s: %s", exitmsg, string(exiterr.Stderr))
 		}
 		return "", fmt.Errorf("Kubectl %v failed: %s, %s", args, errmsg, out)
 	}


### PR DESCRIPTION
If `kubectl get pods -o name` is executed and there are no pods `No resources found` is returned as the result of this command. This is not correct and no output should be returned.  This fixes this behaviour (as `No resources found` is returned on stderr)

Stderr is now returned if an exit status != 0 occurs.

I've also added args to the error, as this makes debugging a bit easier.