### PR TITLE
Add ManageCronjobs to ProcessVariables

### DIFF
--- a/process.go
+++ b/process.go
@@ -33,6 +33,7 @@ type Metadata struct {
 type ProcessVariables struct {
 	Namespace        string
 	ImagePullSecrets []string
+	ManageCronjobs   bool
 	Variables        map[string]interface{}
 }
 


### PR DESCRIPTION
If set to true the Cleanup in KubernetesTarget will also cleanup cronjobs. I've placed this behind a flag because not all Kubernetes clusters have support for cronjobs.